### PR TITLE
Change "1607-22H2" in issues to "1607+" to align with the other issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These issues, unless specified to have been resolved in a later Windows version,
 - "Notification Area Icon" settings in Control Panel are missing (1507+).
 - The taskbar might overlap fullscreen applications whilst immersive shell is enabled (1507+).
 - If a user has StartIsBack++ installed, it may attempt to erroneously hook the shell, causing both visual and functional issues.
-- "Settings" is duplicated in the start menu program list (1607-22H2, fixed system-wide in Windows 11).
+- "Settings" is duplicated in the start menu program list (1607+, fixed system-wide in Windows 11).
 
 **Windows 11**
 - BlurBehind colorization mode no longer works due to the removal of the relevant accent policy (22H2+).


### PR DESCRIPTION
Title says it all. Since Windows 10 is currently on 22H2, the issue still exists as far as I've seen, so it would fit more this way. If it has been patched, it should be mentioned somewhere.