### PR TITLE
Remove invalid licensing clause from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,4 @@ If you're having linker errors because of the prebuilt minhook, do the following
 Contributors: DON'T COMMIT YOUR MODIFIED `libMinHook.x64.lib` UNLESS SPECIFIED!
 
 ## Licensing
-The code for the project is licensed under GPLv3, to allow both for further research and for power-users to be able to make their own modifications. However, in the public interest, for the safety of users and developers alike, inclusion of compiled explorer7 DLL files in any form (whether compiled from source, forks of the source code, or from the release repository) in modified Windows ISOs, or "transformation packs", is strictly prohibited. 
-
-We reserve every right to act against unauthorised usage of the software, as outlined above.
+The code for the project is licensed under GPLv3, to allow both for further research and for power-users to be able to make their own modifications.


### PR DESCRIPTION
This pull request removes a passage from the README which contradicts the license this project is supposedly under.

There are numerous issues with this, as the GPLv3 as a license (and in fact, almost any Free and Open Source software or copyleft media license) is designed to prevent the kind of clause the pull request seeks to remove. Your clause violates 3 of the core freedoms explicitly provided by the GPLv3:

- Freedom 0: The freedom to run the program for any purpose. By prohibiting the software's use within specific environments (modified ISOs), you are restricting the field of use, which explicitly violates this freedom.
- Freedom 2: The freedom to redistribute copies. By banning inclusion in "transformation packs," you are imposing a restriction on how copies can be redistributed.
- Freedom 3: The freedom to distribute modified versions. By strictly prohibiting forks or compiled binaries from being included in these specific distribution methods, you are restricting the distribution of derivative works.

Furthermore, this restriction is legally void under the text of the GPLv3 itself. Section 10 states:

> "You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License."

Because this README clause constitutes a "further restriction," Section 7 of the GPLv3 gives the community explicit permission to remove it:

> "If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term."

When you chose to license your project under the GPLv3, you implicitly agreed to the entire license, including the text as is under Section 10 and Section 7 of the GPLv3. This means even if you take no action, your clause is void and cannot be enforced, and anyone is free to ignore it. As this one has also found out, you have attempted to performed copyright take downs on other projects using this code. Enforcing this restriction via DMCA or take downs constitutes a violation of the GPLv3, as the license itself grants the permissions you are trying to revoke.

You cannot have it both ways; you cannot release code under the GPLv3 to get the benefits of open-source contributions or otherwise, while simultaneously blocking specific use cases or projects you dislike. Similarly, no other FOSS license permits such restriction to occur, as per the OSI definition for what constitutes a "Free and Open Source" software license:

>6. No Discrimination Against Fields of Endeavor
>The license must not restrict anyone from making use of the program in a specific field of endeavor. For example, it may not restrict the program from being used in a business, or from being used for genetic research.

Therefore, you have two options:
- Either you remove the clause and allow this project to be validly licensed under the GPLv3 without a confusing and invalid clause, and cease attempting to use the legal system to attempt to take down other projects.
- Otherwise, if you insist on the restriction, you have to re-license the code under a new, proprietary license, whether you want to mangle your own custom GPLv3 into your preferred shape or not, and it ceases being FOSS; in this case, you may no longer call the project GPLv3-licensed, Free and Open Source, or any other similar terms.

Personally, this one was going to contribute to the project until it had realized this license's terms, it signals to contributors and users the maintainer is not fully serious in regards to FOSS, or maintaining the project, having some kind of unclear baggage likely against other members of the community which they are willing to allow to influence their decisions.

-- Remilia